### PR TITLE
docs(repo): política de gobernanza para agentes de IA

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,43 @@
+# Guía de revisión del proyecto
+
+Este repositorio implementa una estrategia de gestión de configuración sobre tres
+configuration items de Ghost. Al revisar un pull request, verifica lo siguiente.
+
+## Convención de commits
+
+Los mensajes deben seguir el formato `tipo(alcance): descripción (#issue)`.
+
+- Tipos válidos: feat, fix, docs, ci, build, test, refactor, chore
+- Alcances válidos: casper, source, config, docs, repo
+- La descripción debe tener al menos 10 caracteres
+- Debe referenciar el número de un issue
+
+## Independencia de los configuration items
+
+Cada CI vive en su propia carpeta y tiene su propio pipeline:
+
+- `casper/` es el CI-1
+- `source/` es el CI-2
+- `config-entorno/` es el CI-3
+
+Señala cualquier cambio que mezcle archivos de más de un CI en el mismo pull
+request, porque rompe la independencia de sus ciclos de vida.
+
+## Seguridad de la configuración
+
+- Ningún archivo `.env` con valores reales debe versionarse
+- Las credenciales, tokens o contraseñas nunca van en el código ni en los workflows
+- Los valores sensibles se declaran en `.env.example` con el marcador
+  `CAMBIAR_ESTE_VALOR`, nunca con un valor real
+
+## Workflows de GitHub Actions
+
+- Las acciones externas deben estar fijadas a una versión, no a una rama
+- Cada workflow de un CI debe tener filtros por ruta que lo limiten a su carpeta
+- Los permisos deben declararse explícitamente y ser los mínimos necesarios
+
+## Gobernanza de agentes
+
+Según la política definida en `AGENTS.md`, un agente puede revisar y sugerir,
+pero no aprobar pull requests ni modificar workflows de CI/CD. Señala cualquier
+cambio que contradiga esa política.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# Política de gobernanza para agentes de IA
+
+## Contexto
+
+El proyecto Ghost incorpora en sus repositorios archivos de documentación
+dirigidos a agentes de IA (`AGENTS.md` y `CLAUDE.md` en Casper y Source). Esto
+evidencia que los agentes automatizados ya participan en el flujo de desarrollo
+de proyectos reales.
+
+Desde la perspectiva de gestión de configuración, un agente capaz de modificar
+código es un actor más dentro del proceso de control de cambios y, por tanto,
+requiere un rol y unos permisos definidos, igual que un desarrollador humano.
+
+## Alcance de los agentes en este repositorio
+
+| Acción | Permitido | Justificación |
+|--------|-----------|---------------|
+| Revisar y comentar Pull Requests | Sí | Aporta detección temprana sin autoridad de decisión |
+| Sugerir cambios de código | Sí | Las sugerencias las evalúa un revisor humano |
+| Aprobar Pull Requests | No | La aprobación es una autoridad de control de cambios reservada a personas |
+| Hacer merge a `develop` o `main` | No | La integración a ramas protegidas requiere aprobación humana |
+| Modificar los workflows de CI/CD | No | Los pipelines son un CI crítico: un cambio no supervisado comprometería todos los controles |
+| Modificar `.env.example` o secretos | No | Riesgo de exposición de configuración sensible |
+
+## Implementación del control
+
+La política declarada en este documento se implementa de forma ejecutable en
+`.gemini/styleguide.md`, que traduce estas reglas y las convenciones del equipo
+a criterios verificables por el agente de revisión automática en cada pull
+request.
+
+## Trazabilidad de las contribuciones de agentes
+
+Todo aporte generado o asistido por un agente debe quedar identificable:
+
+- Los comentarios de revisión automática quedan registrados en el hilo del Pull
+  Request con el autor identificado como bot.
+- Si un agente genera código que un integrante adopta, el commit debe indicarlo
+  en el cuerpo del mensaje:


### PR DESCRIPTION
Define el rol y los permisos de los agentes de IA dentro del proceso de control
de cambios, y lo implementa como control ejecutable.

### Contenido

- `AGENTS.md`: matriz de acciones permitidas y no permitidas, mecanismo de
  trazabilidad de contribuciones asistidas por IA, y límite explícito frente a
  la aprobación humana
- `.gemini/styleguide.md`: traduce esa política y las convenciones del equipo a
  reglas verificables por el agente de revisión automática

### Justificación

Ghost ya incorpora archivos dirigidos a agentes de IA en sus repositorios. Un
agente capaz de proponer o modificar código es un actor dentro del proceso de
control de cambios y requiere rol y permisos definidos, igual que un
desarrollador humano.

Los dos archivos son complementarios: uno declara la política y el otro la
convierte en un control que se ejecuta sobre cada pull request.

Closes #12