### PR TITLE
ci(repo): automatiza la validación de nombres de rama (#3)

### DIFF
--- a/.github/workflows/branch-lint.yml
+++ b/.github/workflows/branch-lint.yml
@@ -1,0 +1,37 @@
+name: Validación de nombres de rama
+
+on:
+  pull_request:
+    branches: [develop, main]
+
+permissions:
+  contents: read
+
+jobs:
+  validar-nombre-rama:
+    name: Verificar nomenclatura GitFlow
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validar el nombre de la rama de origen
+        run: |
+          RAMA="${{ github.head_ref }}"
+          PATRON='^(feature|release|hotfix)/[a-z0-9][a-z0-9._-]*$'
+
+          echo "Rama evaluada: $RAMA"
+          echo ""
+
+          if echo "$RAMA" | grep -qE "$PATRON"; then
+            echo "OK: el nombre de la rama cumple la convención del equipo."
+            exit 0
+          fi
+
+          echo "El nombre '$RAMA' no cumple la nomenclatura acordada."
+          echo ""
+          echo "Formatos válidos:"
+          echo "  feature/<nombre-corto>   para trabajo nuevo"
+          echo "  release/v<X.Y.Z>         para preparar una versión"
+          echo "  hotfix/<nombre-corto>    para correcciones urgentes sobre main"
+          echo ""
+          echo "Usa solo minúsculas, números, puntos, guiones y guiones bajos."
+          exit 1

--- a/.github/workflows/branch-lint.yml
+++ b/.github/workflows/branch-lint.yml
@@ -14,8 +14,10 @@ jobs:
 
     steps:
       - name: Validar el nombre de la rama de origen
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          RAMA="${{ github.head_ref }}"
+          RAMA="$HEAD_REF"
           PATRON='^(feature|release|hotfix)/[a-z0-9][a-z0-9._-]*$'
 
           echo "Rama evaluada: $RAMA"


### PR DESCRIPTION
Implementa la validación automática de la nomenclatura de ramas según la estrategia GitFlow acordada por el equipo.

Incluye:
- Workflow que se ejecuta al abrir un Pull Request hacia develop o main
- Lectura del nombre de la rama de origen (github.head_ref) y comparación contra el patrón feature/, release/ y hotfix/
- Mensaje de error con los formatos válidos para agilizar la corrección
- Bloqueo del merge cuando la rama no cumple la convención

Automatiza una política propia del equipo (no solo una tarea técnica) y
complementa el commit-lint en el criterio de automatización del control
de configuración.

Closes #3