### PR TITLE
fix(repo): excluye a Dependabot de la validación de nombres de rama

### DIFF
--- a/.github/workflows/branch-lint.yml
+++ b/.github/workflows/branch-lint.yml
@@ -11,6 +11,7 @@ jobs:
   validar-nombre-rama:
     name: Verificar nomenclatura GitFlow
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
 
     steps:
       - name: Validar el nombre de la rama de origen


### PR DESCRIPTION
Los ocho pull requests abiertos por Dependabot fallaban el control de
nomenclatura de ramas, porque su formato (`dependabot/npm_and_yarn/...`) es
fijo y no sigue la convención GitFlow del equipo.

La corrección no modifica el patrón de validación, que sigue siendo estricto
para ramas creadas por personas. En su lugar, se exceptúa la ejecución del
job cuando el autor es `dependabot[bot]`, reconociendo que es una convención
de nomenclatura distinta y legítima, propia de la automatización, no una
violación de la convención del equipo.

Closes #NN