### PR TITLE
refactor(repo): extrae workflow reutilizable para pipelines de temas

### DIFF
--- a/.github/workflows/ci-casper.yml
+++ b/.github/workflows/ci-casper.yml
@@ -6,54 +6,16 @@ on:
     paths:
       - 'casper/**'
       - '.github/workflows/ci-casper.yml'
+      - '.github/workflows/theme-ci.yml'
   pull_request:
     paths:
       - 'casper/**'
       - '.github/workflows/ci-casper.yml'
+      - '.github/workflows/theme-ci.yml'
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 jobs:
-  build:
-    name: Build y validación del tema
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: casper
-
-    steps:
-      - name: Descargar el código
-        uses: actions/checkout@v4
-
-      - name: Instalar pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          package_json_file: casper/package.json
-
-      - name: Instalar Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-          cache-dependency-path: casper/pnpm-lock.yaml
-
-      - name: Instalar dependencias
-        run: pnpm install --frozen-lockfile
-
-      - name: Compilar assets del tema
-        run: pnpm build
-
-      - name: Empaquetar el tema
-        run: pnpm zip
-
-      - name: Validar compatibilidad con gscan
-        run: pnpm exec gscan --fatal --verbose .
-
-      - name: Publicar artefacto del tema
-        uses: actions/upload-artifact@v4
-        with:
-          name: casper-theme
-          path: casper/dist/casper.zip
-          retention-days: 30
+  ci:
+    uses: ./.github/workflows/theme-ci.yml
+    with:
+      theme: casper

--- a/.github/workflows/ci-source.yml
+++ b/.github/workflows/ci-source.yml
@@ -6,54 +6,16 @@ on:
     paths:
       - 'source/**'
       - '.github/workflows/ci-source.yml'
+      - '.github/workflows/theme-ci.yml'
   pull_request:
     paths:
       - 'source/**'
       - '.github/workflows/ci-source.yml'
+      - '.github/workflows/theme-ci.yml'
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 jobs:
-  build:
-    name: Build y validación del tema
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: source
-
-    steps:
-      - name: Descargar el código
-        uses: actions/checkout@v4
-
-      - name: Instalar pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          package_json_file: source/package.json
-
-      - name: Instalar Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-          cache-dependency-path: source/pnpm-lock.yaml
-
-      - name: Instalar dependencias
-        run: pnpm install --frozen-lockfile
-
-      - name: Compilar assets del tema
-        run: pnpm build
-
-      - name: Empaquetar el tema
-        run: pnpm zip
-
-      - name: Validar compatibilidad con gscan
-        run: pnpm exec gscan --fatal --verbose .
-
-      - name: Publicar artefacto del tema
-        uses: actions/upload-artifact@v4
-        with:
-          name: source-theme
-          path: source/dist/source.zip
-          retention-days: 30
+  ci:
+    uses: ./.github/workflows/theme-ci.yml
+    with:
+      theme: source

--- a/.github/workflows/theme-ci.yml
+++ b/.github/workflows/theme-ci.yml
@@ -1,0 +1,56 @@
+name: CI reutilizable - Tema de Ghost
+
+on:
+  workflow_call:
+    inputs:
+      theme:
+        description: Carpeta del tema a construir
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build y validación del tema
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Descargar el código
+        uses: actions/checkout@v4
+
+      - name: Instalar pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          package_json_file: ${{ inputs.theme }}/package.json
+
+      - name: Instalar Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: ${{ inputs.theme }}/pnpm-lock.yaml
+
+      - name: Instalar dependencias
+        working-directory: ${{ inputs.theme }}
+        run: pnpm install --frozen-lockfile
+
+      - name: Compilar assets del tema
+        working-directory: ${{ inputs.theme }}
+        run: pnpm build
+
+      - name: Empaquetar el tema
+        working-directory: ${{ inputs.theme }}
+        run: pnpm zip
+
+      - name: Validar compatibilidad con gscan
+        working-directory: ${{ inputs.theme }}
+        run: pnpm exec gscan --fatal --verbose .
+
+      - name: Publicar artefacto del tema
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.theme }}-theme
+          path: ${{ inputs.theme }}/dist/${{ inputs.theme }}.zip
+          retention-days: 30


### PR DESCRIPTION
Implementa la refactorización diseñada en el Taller de la Sesión 5, aplicando
dos técnicas del catálogo de Fowler (2018).

### Refactorizaciones aplicadas

**Extract Function**: los pasos comunes de instalación, build, empaquetado y
validación con gscan se extraen a `theme-ci.yml`, una unidad con nombre propio
y responsabilidad única, en vez de estar repetidos en dos archivos.

**Parameterize Function**: `ci-casper.yml` y `ci-source.yml` eran la misma
secuencia de pasos diferenciada solo por el nombre del tema. El parámetro
`theme` del `workflow_call` absorbe esa diferencia.

### Resultado medido

| Métrica | Antes | Después |
|---------|-------|---------|
| Líneas totales | 117| 98|
| Líneas de lógica duplicada | 2| 1 |
| Puntos de cambio ante una modificación de política de build | 2 | 1 |

Los filtros por ruta se conservan en cada archivo delgado, así que cada
configuration item sigue disparando su propio pipeline de forma independiente.

Closes #33
