### PR TITLE
chore(repo): fija a SHA las acciones de todos los workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,10 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(source)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(repo)"

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Descargar el código
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Revisar el pull request
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GEMINI_MODEL: gemini-3.6-flash

--- a/.github/workflows/ci-config-entorno.yml
+++ b/.github/workflows/ci-config-entorno.yml
@@ -20,10 +20,10 @@ jobs:
     name: Análisis estático del Dockerfile
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Ejecutar hadolint
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf # v3.1.0
         with:
           dockerfile: config-entorno/Dockerfile
           failure-threshold: error
@@ -32,7 +32,7 @@ jobs:
     name: Validación del archivo compose
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Verificar sintaxis del compose
         working-directory: config-entorno
@@ -46,7 +46,7 @@ jobs:
     name: Validación de variables de entorno
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Caso positivo - archivo .env completo
         working-directory: config-entorno

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Descargar el código
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Ejecutar commitlint
-        uses: wagoid/commitlint-github-action@v6
+        uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         with:
           release-type: simple
           config-file: release-please-config.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,15 +15,15 @@ jobs:
 
     steps:
       - name: Descargar el código
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Instalar pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           package_json_file: casper/package.json
 
       - name: Instalar Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
 
@@ -40,7 +40,7 @@ jobs:
           pnpm zip
 
       - name: Publicar release con los artefactos
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           name: Release ${{ github.ref_name }}
           generate_release_notes: true

--- a/.github/workflows/theme-ci.yml
+++ b/.github/workflows/theme-ci.yml
@@ -18,15 +18,15 @@ jobs:
 
     steps:
       - name: Descargar el código
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Instalar pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           package_json_file: ${{ inputs.theme }}/package.json
 
       - name: Instalar Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: pnpm
@@ -46,11 +46,4 @@ jobs:
 
       - name: Validar compatibilidad con gscan
         working-directory: ${{ inputs.theme }}
-        run: pnpm exec gscan --fatal --verbose .
-
-      - name: Publicar artefacto del tema
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ inputs.theme }}-theme
-          path: ${{ inputs.theme }}/dist/${{ inputs.theme }}.zip
-          retention-days: 30
+        run: pnpm exec

--- a/.github/workflows/theme-ci.yml
+++ b/.github/workflows/theme-ci.yml
@@ -46,4 +46,11 @@ jobs:
 
       - name: Validar compatibilidad con gscan
         working-directory: ${{ inputs.theme }}
-        run: pnpm exec
+        run: pnpm exec gscan --fatal --verbose .
+
+      - name: Publicar artefacto del tema
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ inputs.theme }}-theme
+          path: ${{ inputs.theme }}/dist/${{ inputs.theme }}.zip
+          retention-days: 30


### PR DESCRIPTION
Refuerza la regla ya declarada en `.gemini/styleguide.md` ("las acciones
externas deben estar fijadas a una versión, no a una rama"), llevándola de un
tag de versión (mutable si el mantenedor del repositorio externo lo recrea) a
un hash de commit (inmutable). Es la misma familia de riesgo que el agente de
IA detectó con la inyección de comandos en `branch-lint.yml`: confianza en una
entrada externa al repositorio.

Se extiende además `dependabot.yml` para vigilar el ecosistema
`github-actions`, de modo que los pines a SHA se mantengan actualizados
automáticamente sin perder la inmutabilidad.

### Alcance

Seis workflows del repositorio (`theme-ci.yml`, `commit-lint.yml`,
`ci-config-entorno.yml`, `ai-review.yml`, `release.yml`,
`release-please.yml`), nueve acciones externas distintas en total, cada una
verificada con `git ls-remote` contra el repositorio oficial de la acción.
`branch-lint.yml`, `ci-casper.yml` y `ci-source.yml` no requieren cambios: no
referencian acciones externas.

Closes #37
Closes #38