### PR TITLE
fix(repo): excluye a dependabot de commitlint

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,3 +1,12 @@
+name: Validación de convención de commits
+
+on:
+  pull_request:
+    branches: [develop, main]
+
+permissions:
+  contents: read
+
 jobs:
   commitlint:
     name: Verificar Conventional Commits


### PR DESCRIPTION
Corrige un choque real entre dos de las cinco mejoras: la regla `references-empty`
de commitlint (mejora 2, modernización) exige que todo commit referencie un issue
con `#`, pero los commits que genera Dependabot (mejora 3) nunca lo hacen, porque
el bot no tiene forma de conocer un número de issue.

Como consecuencia, los 7 pull requests abiertos de Dependabot estaban fallando el
check de commit-lint de forma permanente, sin que ningún commit humano estuviera
involucrado.

### La solución, mismo patrón que ya existe en branch-lint.yml

`branch-lint.yml` ya resolvió el mismo tipo de conflicto (las ramas de Dependabot
tampoco seguían la nomenclatura GitFlow) excluyendo al bot a nivel de job con
`if: github.actor != 'dependabot[bot]'`. Se aplica exactamente la misma condición
a `commit-lint.yml`, sin debilitar la regla para commits humanos.

Closes #64