### PR TITLE
fix(repo): dispara release.yml desde release-please sin usar PAT

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,13 +7,27 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+        id: release
         with:
           release-type: simple
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Disparar la publicación de artefactos
+        if: ${{ steps.release.outputs.release_created }}
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'release.yml',
+              ref: '${{ steps.release.outputs.tag_name }}',
+            });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Corrige un problema que habría dejado el primer release automático sin artefactos.

### El problema

`release-please.yml` usa el `GITHUB_TOKEN` por defecto (no especifica `token:`).
GitHub documenta explícitamente que los recursos creados con ese token —incluido
el tag que release-please publica al mergear su PR de versión— no disparan otros
workflows. `release.yml` espera justo ese evento (`push: tags: ['v*']`) para
compilar y publicar los artefactos de Casper y Source, así que se habría quedado
dormido: el release se publica, pero sin los .zip adjuntos.

### La solución evaluada y la descartada

Se evaluaron dos opciones. Usar un Personal Access Token en vez del GITHUB_TOKEN
es la que documenta la acción oficialmente, pero introduce un secreto nuevo que
alguien del equipo tiene que gestionar y rotar a mano, la misma clase de
dependencia externa manual que ya se eliminó con el fijado a SHA.

Se adoptó en cambio disparar `release.yml` explícitamente: `release-please-action`
expone como output el tag que acaba de crear, y un paso adicional con
`actions/github-script` —la misma acción que ya usa `ai-review.yml`— llama a la
API para disparar