### PR TITLE
fix(repo): commitlint solo valida PR hacia develop, no hacia main

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -2,7 +2,7 @@ name: Validación de convención de commits
 
 on:
   pull_request:
-    branches: [develop, main]
+    branches: [develop]
 
 permissions:
   contents: read


### PR DESCRIPTION
Aplica a develop el mismo fix que ya viaja hacia main a través de #68, para que
ambas ramas no queden desincronizadas en este archivo.

Un pull request de sincronización entre develop y main trae consigo commits ya
aprobados anteriormente, incluidos los de Dependabot, que nunca tuvieron
referencia a issue. commitlint los revalida igual porque valida todo el rango
de commits del PR, no solo el más reciente, lo que hace fallar ese tipo de PR
por commits que ya pasaron su propia validación al entrar a develop.

Se limita el disparador a pull requests hacia develop, que es donde el trabajo
nuevo entra de verdad. main solo recibe contenido ya validado desde develop, así
que revalidarlo ahí es redundante.

Closes #70